### PR TITLE
Add getNextEpochTime

### DIFF
--- a/packages/melon.js/lib/pricefeeds/calls/getNextEpochTime.js
+++ b/packages/melon.js/lib/pricefeeds/calls/getNextEpochTime.js
@@ -1,0 +1,12 @@
+// @flow
+import getCanonicalPriceFeedContract from '../contracts/getCanonicalPriceFeedContract';
+
+const getNextEpochTime = async (environment): Promise<any> => {
+  const canonicalPriceFeedContract = await getCanonicalPriceFeedContract(
+    environment,
+  );
+
+  return canonicalPriceFeedContract.instance.getNextEpochTime.call({}, []);
+};
+
+export default getNextEpochTime;


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

Add function to get the next epoch time for the canonical price feed.

### Changed

### Deprecated

### Removed

### Fixed

### Security
